### PR TITLE
pep-0263 - Add source code UTF-8 encoding

### DIFF
--- a/yaml-cli.py
+++ b/yaml-cli.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
 import sys
 from ruamel.yaml import YAML
 


### PR DESCRIPTION
Define encoding for source file `yaml-cli.py`

Before the fix:
```
$ python yaml-cli.py
  File "yaml-cli.py", line 64
SyntaxError: Non-ASCII character '\xc3' in file yaml-cli.py on line 65, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

References:
* https://www.python.org/dev/peps/pep-0263/